### PR TITLE
Issue 569

### DIFF
--- a/README.md
+++ b/README.md
@@ -11302,8 +11302,33 @@ module.exports = class GraphQL {
 
 /**
  * Description.
- * @param {Object} options Options.
- * @param {Object} options.foo A description.
+ * @param {Object} options
+ * @param {Object} options.foo
+ */
+function quux ({ foo: { bar } }) {}
+// Message: Missing JSDoc @param "options.foo.bar" declaration.
+
+/**
+ * Description.
+ * @param {FooBar} options
+ * @param {FooBar} options.foo
+ */
+function quux ({ foo: { bar } }) {}
+// Options: [{"checkTypesPattern":"FooBar"}]
+// Message: Missing JSDoc @param "options.foo.bar" declaration.
+
+/**
+ * Description.
+ * @param {Object} options
+ * @param {FooBar} foo
+ */
+function quux ({ foo: { bar } }) {}
+// Message: Missing JSDoc @param "options.foo" declaration.
+
+/**
+ * Description.
+ * @param {Object} options
+ * @param options.foo
  */
 function quux ({ foo: { bar } }) {}
 // Message: Missing JSDoc @param "options.foo.bar" declaration.
@@ -11884,10 +11909,18 @@ module.exports = function a(b) {
 
 /**
  * Description.
- * @param {object} options Options.
- * @param {FooBar} options.foo A description.
+ * @param {Object} options Options.
+ * @param {FooBar} options.foo foo description.
  */
 function quux ({ foo: { bar } }) {}
+
+/**
+ * Description.
+ * @param {FooBar} options
+ * @param {Object} options.foo
+ */
+function quux ({ foo: { bar } }) {}
+// Options: [{"checkTypesPattern":"FooBar"}]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -11873,6 +11873,20 @@ function quux ({foo: bar}) {
 module.exports = function a(b) {
   console.info(b);
 };
+
+/**
+ * Description.
+ * @param {object} options Options.
+ * @param {FooBar} options.foo A description.
+ */
+function quux ({ foo: { bar } }) {}
+
+/**
+ * Description.
+ * @param {Foo} options Options.
+ * @param {FooBar} options.a A description.
+ */
+function quux ({ foo: { bar } }) {}
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -11299,6 +11299,14 @@ module.exports = class GraphQL {
 	}
 })();
 // Message: Missing JSDoc @param "param" declaration.
+
+/**
+ * Description.
+ * @param {Object} options Options.
+ * @param {Object} options.foo A description.
+ */
+function quux ({ foo: { bar } }) {}
+// Message: Missing JSDoc @param "options.foo.bar" declaration.
 ````
 
 The following patterns are not considered problems:
@@ -11878,13 +11886,6 @@ module.exports = function a(b) {
  * Description.
  * @param {object} options Options.
  * @param {FooBar} options.foo A description.
- */
-function quux ({ foo: { bar } }) {}
-
-/**
- * Description.
- * @param {Foo} options Options.
- * @param {FooBar} options.a A description.
  */
 function quux ({ foo: { bar } }) {}
 ````

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -179,9 +179,8 @@ export default iterateJsdoc(({
 
         const fullParamName = `${rootName}.${paramName}`;
 
-        // eslint-disable-next-line no-shadow
-        const notCheckingName = jsdocParameterNames.find(({name, type}) => {
-          return utils.comparePaths(name)(fullParamName) && type.search(checkTypesRegex) === -1 && type !== '';
+        const notCheckingName = jsdocParameterNames.find(({name, type: paramType}) => {
+          return utils.comparePaths(name)(fullParamName) && paramType.search(checkTypesRegex) === -1 && paramType !== '';
         });
 
         if (notCheckingName !== undefined) {

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -130,6 +130,7 @@ export default iterateJsdoc(({
       }
 
       const {hasRestElement, hasPropertyRest, rests, names} = functionParameterName[1];
+      const notCheckingNames = [];
       if (!enableRestElementFixer && hasRestElement) {
         return;
       }
@@ -177,6 +178,21 @@ export default iterateJsdoc(({
         }
 
         const fullParamName = `${rootName}.${paramName}`;
+
+        // eslint-disable-next-line no-shadow
+        const notCheckingName = jsdocParameterNames.find(({name, type}) => {
+          return utils.comparePaths(name)(fullParamName) && type.search(checkTypesRegex) === -1 && type !== '';
+        });
+
+        if (notCheckingName !== undefined) {
+          notCheckingNames.push(notCheckingName.name);
+        }
+
+        if (notCheckingNames.find((name) => {
+          return new RegExp('^' + name).test(fullParamName);
+        })) {
+          return;
+        }
 
         if (jsdocParameterNames && !jsdocParameterNames.find(({name}) => {
           return utils.comparePaths(name)(fullParamName);

--- a/src/rules/requireParam.js
+++ b/src/rules/requireParam.js
@@ -188,7 +188,7 @@ export default iterateJsdoc(({
         }
 
         if (notCheckingNames.find((name) => {
-          return new RegExp('^' + name).test(fullParamName);
+          return fullParamName.startsWith(name);
         })) {
           return;
         }

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -1991,8 +1991,8 @@ export default {
       code: `
       /**
        * Description.
-       * @param {Object} options Options.
-       * @param {Object} options.foo A description.
+       * @param {Object} options
+       * @param {Object} options.foo
        */
       function quux ({ foo: { bar } }) {}
       `,
@@ -2004,8 +2004,89 @@ export default {
       output: `
       /**
        * Description.
-       * @param {Object} options Options.
-       * @param {Object} options.foo A description.
+       * @param {Object} options
+       * @param {Object} options.foo
+       * @param options.foo.bar
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {FooBar} options
+       * @param {FooBar} options.foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "options.foo.bar" declaration.',
+        },
+      ],
+      options: [
+        {
+          checkTypesPattern: 'FooBar',
+        },
+      ],
+      output: `
+      /**
+       * Description.
+       * @param {FooBar} options
+       * @param {FooBar} options.foo
+       * @param options.foo.bar
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param {FooBar} foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "options.foo" declaration.',
+        },
+        {
+          message: 'Missing JSDoc @param "options.foo.bar" declaration.',
+        },
+      ],
+      output: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param options.foo
+       * @param {FooBar} foo
+       * @param options.foo.bar
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param options.foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "options.foo.bar" declaration.',
+        },
+      ],
+      output: `
+      /**
+       * Description.
+       * @param {Object} options
+       * @param options.foo
        * @param options.foo.bar
        */
       function quux ({ foo: { bar } }) {}
@@ -2882,11 +2963,26 @@ export default {
       code: `
       /**
        * Description.
-       * @param {object} options Options.
-       * @param {FooBar} options.foo A description.
+       * @param {Object} options Options.
+       * @param {FooBar} options.foo foo description.
        */
       function quux ({ foo: { bar } }) {}
       `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {FooBar} options
+       * @param {Object} options.foo
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      options: [
+        {
+          checkTypesPattern: 'FooBar',
+        },
+      ],
     },
   ],
 };

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -1987,6 +1987,30 @@ export default {
       `,
       /* eslint-enable no-tabs */
     },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Object} options Options.
+       * @param {Object} options.foo A description.
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+      errors: [
+        {
+          message: 'Missing JSDoc @param "options.foo.bar" declaration.',
+        },
+      ],
+      output: `
+      /**
+       * Description.
+       * @param {Object} options Options.
+       * @param {Object} options.foo A description.
+       * @param options.foo.bar
+       */
+      function quux ({ foo: { bar } }) {}
+      `,
+    },
   ],
   valid: [
     {
@@ -2860,16 +2884,6 @@ export default {
        * Description.
        * @param {object} options Options.
        * @param {FooBar} options.foo A description.
-       */
-      function quux ({ foo: { bar } }) {}
-      `,
-    },
-    {
-      code: `
-      /**
-       * Description.
-       * @param {Foo} options Options.
-       * @param {FooBar} options.a A description.
        */
       function quux ({ foo: { bar } }) {}
       `,

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -2859,9 +2859,9 @@ export default {
       /**
        * Description.
        * @param {object} options Options.
-       * @param {FooBar} options.a A description.
+       * @param {FooBar} options.foo A description.
        */
-      function foo({ a: { b } }) {}
+      function quux ({ foo: { bar } }) {}
       `,
     },
     {
@@ -2871,7 +2871,7 @@ export default {
        * @param {Foo} options Options.
        * @param {FooBar} options.a A description.
        */
-      function foo({ a: { b } }) {}
+      function quux ({ foo: { bar } }) {}
       `,
     },
   ],

--- a/test/rules/assertions/requireParam.js
+++ b/test/rules/assertions/requireParam.js
@@ -2854,5 +2854,25 @@ export default {
       };
       `,
     },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {object} options Options.
+       * @param {FooBar} options.a A description.
+       */
+      function foo({ a: { b } }) {}
+      `,
+    },
+    {
+      code: `
+      /**
+       * Description.
+       * @param {Foo} options Options.
+       * @param {FooBar} options.a A description.
+       */
+      function foo({ a: { b } }) {}
+      `,
+    },
   ],
 };


### PR DESCRIPTION
1. 성능 향상을 위해 정규식 제외, `startsWith`로 대체
2. Test case 추가
- `path` 가 다른 경우
- `paramType` 이 없는 경우
- `checkTypePattern` (`checkTypesRegex`와 같음) 값이 변경된 경우 (valid)
- `checkTypePattern` (`checkTypesRegex`와 같음) 값이 변경된 경우 (invalid)